### PR TITLE
treat auth.User when AUTH_USER_MODEL is specified for another

### DIFF
--- a/django_comment_migrate/apps.py
+++ b/django_comment_migrate/apps.py
@@ -7,7 +7,7 @@ from django_comment_migrate.utils import get_migrations_app_models
 
 
 def handle_post_migrate(app_config, using=DEFAULT_DB_ALIAS, **kwargs):
-    migrations = (migration for migration, _ in kwargs.get('plan', []))
+    migrations = (migration for migration, rollback in kwargs.get('plan', []) if not rollback)
     app_models = get_migrations_app_models(migrations, apps, using)
     migrate_app_models_help_text_to_database(app_models, using)
 

--- a/django_comment_migrate/apps.py
+++ b/django_comment_migrate/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig, apps
+from django.contrib.auth import get_user_model
 from django.db import DEFAULT_DB_ALIAS
 from django.db.models.signals import post_migrate
 
@@ -7,8 +8,13 @@ from django_comment_migrate.utils import get_migrations_app_models
 
 
 def handle_post_migrate(app_config, using=DEFAULT_DB_ALIAS, **kwargs):
+    from django.contrib.auth.models import User
+
     migrations = (migration for migration, rollback in kwargs.get('plan', []) if not rollback)
     app_models = get_migrations_app_models(migrations, apps, using)
+    # another user model is specified instead.
+    if get_user_model() != User:
+        app_models -= {User}
     migrate_app_models_help_text_to_database(app_models, using)
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.contrib.auth import models as auth_models
 
 
 class CommentModel(models.Model):
@@ -10,3 +11,8 @@ class CommentModel(models.Model):
     class Meta:
         app_label = 'tests'
         db_table = 'user'
+
+
+class AnotherUserModel(auth_models.AbstractBaseUser):
+    class Meta:
+        app_label = 'tests'


### PR DESCRIPTION
你好!

When `AUTH_USER_MODEL` is defined for another model, Django doesn't create `auth_user` table during migration. But `auth.User` exists in `app_models`. Because the migrations have information of `auth.User`. So it should be dropped.