### PR TITLE
Bugfix delete model

### DIFF
--- a/README-zh_CN.rst
+++ b/README-zh_CN.rst
@@ -51,7 +51,15 @@ Django Comment Migrate
                db_table = 'comment_model'
                verbose_name = '这是表注释'
 
-4. 执行数据库迁移::
+4. 添加app
+
+    project/app/settings.py
+
+   .. code:: python
+
+       DCM_COMMENT_APP=["app"]
+
+5. 执行数据库迁移::
 
     python manage.py makemigrations
     python manage.py migrate

--- a/README-zh_CN.rst
+++ b/README-zh_CN.rst
@@ -76,6 +76,7 @@ Django Comment Migrate
     DCM_BACKEND={ # 如果自定义了数据的engine，可以使用该配置
             "my-engine": "django_comment_migrate.backends.mysql.CommentMigration"
     }
+    DCM_COMMENT_APP=["app"]   # 如果不配置则默认生成所有表的注释
 
 
 Command

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,7 @@ In settings.py::
     DCM_BACKEND={
             "new-engine": "engine.path"
     }
+    DCM_COMMENT_APP=["app"]
 
 Command
 -------

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,15 @@ Examples
                db_table = 'comment_model'
                verbose_name = 'It is Comment Table'
 
-4. execute database migrate::
+4. add app
+
+    project/app/settings.py
+
+   .. code:: python
+
+       DCM_COMMENT_APP=["app"]
+
+5. execute database migrate::
 
     python manage.py makemigrations
     python manage.py migrate

--- a/django_comment_migrate/config.py
+++ b/django_comment_migrate/config.py
@@ -6,6 +6,7 @@ class DCMConfig:
         "DCM_COMMENT_KEY": "help_text",
         "DCM_TABLE_COMMENT_KEY": "verbose_name",
         "DCM_BACKEND": None,
+        "DCM_COMMENT_APP": []
     }
 
     def __getattr__(self, name):


### PR DESCRIPTION
1.如果migrations当中出现了DeleteModel，此时migrate时遇到先前的CreateModel就会报错，找不到对应的表，添加异常判断规避这种情况。
![image](https://user-images.githubusercontent.com/37009583/154028138-9a66743e-5242-4cd3-8250-e78ca7bfe763.png)

2.生成注释时不区分app，会导致为一些第三方包中的表也生成注释，这执行了不必要的操作且增加migrate时间，所以添加了DCM_COMMENT_APP来配置需要生成注释的app